### PR TITLE
Read from xz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
       - checkout
       - run:
           command: |
+            . .circleci/setup_debian.sh
             . .circleci/gcc_test.sh
 
   "gcc6":
@@ -85,6 +86,7 @@ jobs:
       - checkout
       - run:
           command: |
+            . .circleci/setup_debian.sh
             . .circleci/gcc_test.sh
 
   "gcc7":
@@ -95,6 +97,7 @@ jobs:
       - checkout
       - run:
           command: |
+            . .circleci/setup_debian.sh
             . .circleci/gcc_test.sh
 
   "gcclatest":
@@ -105,6 +108,7 @@ jobs:
       - checkout
       - run:
           command: |
+            . .circleci/setup_debian.sh
             . .circleci/gcc_test.sh
 
   "debian-stretch-gcc":

--- a/.circleci/setup_circleimg.sh
+++ b/.circleci/setup_circleimg.sh
@@ -8,4 +8,4 @@
 #
 
 sudo apt-get update || sudo apt-get --allow-releaseinfo-change-suite update
-sudo apt-get install -y cmake python-pip python-dev build-essential
+sudo apt-get install -y cmake python-pip python-dev build-essential libboost-all-dev

--- a/.circleci/setup_debian.sh
+++ b/.circleci/setup_debian.sh
@@ -8,4 +8,4 @@
 #
 
 apt-get update
-apt-get install -y vim g++ make cmake wget git python-pip python-dev build-essential
+apt-get install -y vim g++ make cmake wget git python-pip python-dev build-essential libboost-all-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           swap-storage: true
 
       - name: "Build image"
-        run: docker -t aymara/fasttext_manylinux_2_28:latest .
+        run: docker build -t aymara/fasttext_manylinux_2_28:latest .
 
       - name: "Push docker image"
         run: docker push aymara/fasttext_manylinux_2_28:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
         name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.AYMARA_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.AYMARA_DOCKERHUB_TOKEN }}
 
       - name: "Checkout code"
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+on:
+  push:
+    branches:
+    - read_from_xz
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+
+  fasttext_manylinux_2_28:
+    name: "Build fastText for Manylinux 2.28"
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      - name: "Build image"
+        run: docker -t aymara/fasttext_manylinux_2_28:latest .
+
+      - name: "Push docker image"
+        run: docker push aymara/fasttext_manylinux_2_28:latest
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.sif
+*.kdev4
 .*.swp
 *.o
 *.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ project(fasttext)
 set (fasttext_VERSION_MAJOR 0)
 set (fasttext_VERSION_MINOR 1)
 
+option(READ_FROM_XZ "Building with libboost::iostreams (allows archive reading)" ON)
+
+if (READ_FROM_XZ)
+  find_package(Boost         1.46  REQUIRED COMPONENTS iostreams)
+endif()
+
 include_directories(fasttext)
 
 set(CMAKE_CXX_FLAGS " -pthread -std=c++11 -funroll-loops -O3 -march=native")
@@ -65,7 +71,12 @@ set_target_properties(fasttext-static PROPERTIES OUTPUT_NAME fasttext)
 set_target_properties(fasttext-static_pic PROPERTIES OUTPUT_NAME fasttext_pic
   POSITION_INDEPENDENT_CODE True)
 add_executable(fasttext-bin src/main.cc)
-target_link_libraries(fasttext-bin pthread fasttext-static)
+
+if (READ_FROM_XZ)
+  target_link_libraries(fasttext-bin pthread fasttext-static Boost::iostreams)
+else()
+  target_link_libraries(fasttext-bin pthread fasttext-static)
+endif()
 set_target_properties(fasttext-bin PROPERTIES PUBLIC_HEADER "${HEADER_FILES}" OUTPUT_NAME fasttext)
 install (TARGETS fasttext-shared
     LIBRARY DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.22)
 project(fasttext)
 
 # The version number.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+ARG MANYLINUX_TAG="2022-10-25-fbea779"
+FROM quay.io/pypa/manylinux_2_28_x86_64:${MANYLINUX_TAG}
+
+# ARG GCC_VERSION
+# ARG QT_VERSION
+# ARG QT_VERSION_MAJOR
+# ARG QT_VERSION_MINOR
+# ARG QT_VERSION_PATCH
+# ARG QT_FULL_VERSION
+# ARG PYTHON_VERSION
+# ARG PYTHON_SHORT_VERSION
+# ARG PYTHON_FULL_VERSION
+# ENV PATH="/opt/python/${PYTHON_SHORT_VERSION}/bin:${PATH}"
+
+RUN yum install -y wget ninja-build boost-devel.x86_64
+
+ENV BUILD_TARGET=/build
+ENV SRC=/src
+
+RUN mkdir -p "$BUILD_TARGET"
+
+WORKDIR ${BUILD_TARGET}
+COPY CMakeLists.txt fasttext.pc.in ${SRC}/
+COPY src ${SRC}/src/
+# COPY . ${SRC}/
+RUN ls /src
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr ../src -G Ninja && cmake --build . --parallel && cmake --install .
+

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ fasttext.o: src/fasttext.cc src/*.h
 	$(CXX) $(CXXFLAGS) -c src/fasttext.cc
 
 fasttext: $(OBJS) src/fasttext.cc src/main.cc
-	$(CXX) $(CXXFLAGS) $(OBJS) src/main.cc -o fasttext
+	$(CXX) $(CXXFLAGS) $(OBJS) -lboost_iostreams src/main.cc -o fasttext
 
 clean:
 	rm -rf *.o *.gcno *.gcda fasttext *.bc webassembly/fasttext_wasm.js webassembly/fasttext_wasm.wasm

--- a/src/archivereader.h
+++ b/src/archivereader.h
@@ -1,0 +1,72 @@
+/**
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "utils.h"
+
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/lzma.hpp>
+
+namespace fasttext {
+namespace impl {
+
+class ArchiveReader {
+public:
+  ArchiveReader(const std::string& filename)
+    : filename_(filename),
+      src_(filename_, std::ios_base::in | std::ios_base::binary),
+      dont_close_src_(false) {
+    if (!src_.is_open()) {
+      throw std::invalid_argument(filename_ + " cannot be opened");
+    }
+
+    reset();
+  }
+
+  ArchiveReader(std::istream& src) {
+    impl_.push(src);
+    dont_close_src_ = true;
+  }
+
+  virtual ~ArchiveReader() {
+    while (!impl_.empty()) {
+      impl_.pop();
+    }
+    if (!dont_close_src_ && src_.is_open()) {
+      src_.close();
+    }
+  }
+
+  void reset() {
+    src_.clear();
+    src_.seekg(std::streampos(0));
+    while (!impl_.empty()) {
+      impl_.pop();
+    }
+    if (utils::endsWith(filename_, ".xz")) {
+      impl_.push(boost::iostreams::lzma_decompressor());
+    }
+    impl_.push(src_);
+  }
+
+  inline std::istream& stream() {
+    return impl_;
+  }
+
+  inline bool eof() {
+    return impl_.eof();
+  }
+
+private:
+  std::string filename_;
+  boost::iostreams::filtering_istream impl_;
+  std::ifstream src_;
+  bool dont_close_src_;
+};
+
+}
+}

--- a/src/archivereader.h
+++ b/src/archivereader.h
@@ -9,6 +9,7 @@
 
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filter/lzma.hpp>
 
 namespace fasttext {
@@ -49,6 +50,9 @@ public:
     }
     if (utils::endsWith(filename_, ".xz")) {
       impl_.push(boost::iostreams::lzma_decompressor());
+    }
+    else if (utils::endsWith(filename_, ".gz")) {
+      impl_.push(boost::iostreams::gzip_decompressor());
     }
     impl_.push(src_);
   }

--- a/src/args.cc
+++ b/src/args.cc
@@ -51,6 +51,8 @@ Args::Args() {
   autotunePredictions = 1;
   autotuneDuration = 60 * 5; // 5 minutes
   autotuneModelSize = "";
+
+  intermSaveStep = 0;
 }
 
 std::string Args::lossToString(loss_name ln) const {
@@ -213,6 +215,8 @@ void Args::parseArgs(const std::vector<std::string>& args) {
         autotuneDuration = std::stoi(args.at(ai + 1));
       } else if (args[ai] == "-autotune-modelsize") {
         autotuneModelSize = std::string(args.at(ai + 1));
+      } else if (args[ai] == "-interm-save-step") {
+        intermSaveStep = std::stoi(args.at(ai+1));
       } else {
         std::cerr << "Unknown argument: " << args[ai] << std::endl;
         printHelp();

--- a/src/args.h
+++ b/src/args.h
@@ -72,6 +72,8 @@ class Args {
   int autotuneDuration;
   std::string autotuneModelSize;
 
+  int intermSaveStep;
+
   void parseArgs(const std::vector<std::string>& args);
   void printHelp();
   void printBasicHelp();

--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -344,6 +344,7 @@ void Dictionary::reset(std::istream& in) const {
   if (in.eof()) {
     in.clear();
     in.seekg(std::streampos(0));
+    std::cerr << "EOF reached" << std::endl;
   }
 }
 

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -19,6 +19,8 @@
 #include "args.h"
 #include "real.h"
 
+#include "archivereader.h"
+
 namespace fasttext {
 
 typedef int32_t id_type;
@@ -41,6 +43,7 @@ class Dictionary {
   void initTableDiscard();
   void initNgrams();
   void reset(std::istream&) const;
+  void reset(impl::ArchiveReader&) const;
   void pushHash(std::vector<int32_t>&, int32_t) const;
   void addSubwords(std::vector<int32_t>&, const std::string&, int32_t) const;
 
@@ -60,6 +63,18 @@ class Dictionary {
       std::vector<int32_t>& line,
       const std::vector<int32_t>& hashes,
       int32_t n) const;
+
+  inline bool getLine_impl(const std::string& token,
+                           int32_t& ntokens,
+                           std::uniform_real_distribution<>& uniform,
+                           std::vector<int32_t>& words,
+                           std::minstd_rand& rng) const;
+
+  inline bool getLine_impl(std::vector<int32_t> word_hashes,
+                           const std::string& token,
+                           int32_t& ntokens,
+                           std::vector<int32_t>& words,
+                           std::vector<int32_t>& labels) const;
 
  public:
   static const std::string EOS;
@@ -97,7 +112,11 @@ class Dictionary {
   std::vector<int64_t> getCounts(entry_type) const;
   int32_t getLine(std::istream&, std::vector<int32_t>&, std::vector<int32_t>&)
       const;
+  int32_t getLine(impl::ArchiveReader&, std::vector<int32_t>&, std::vector<int32_t>&)
+      const;
   int32_t getLine(std::istream&, std::vector<int32_t>&, std::minstd_rand&)
+      const;
+  int32_t getLine(impl::ArchiveReader&, std::vector<int32_t>&, std::minstd_rand&)
       const;
   void threshold(int64_t, int64_t);
   void prune(std::vector<int32_t>&);

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -860,7 +860,7 @@ void FastText::startThreads(const TrainCallback& callback) {
   trainException_ = nullptr;
   std::vector<std::thread> threads;
   if (args_->thread > 1) {
-    if (utils::endsWith(args_->input, ".xz")) {
+    if (utils::endsWith(args_->input, ".xz") || utils::endsWith(args_->input, ".gz")) {
       throw std::invalid_argument("Cannot use multiple threads with archived input file!");
     }
     if (args_->intermSaveStep > 0) {
@@ -870,7 +870,7 @@ void FastText::startThreads(const TrainCallback& callback) {
       threads.push_back(std::thread([=]() { trainThread(i, callback); }));
     }
   } else {
-    if (utils::endsWith(args_->input, ".xz")) {
+    if (utils::endsWith(args_->input, ".xz") || utils::endsWith(args_->input, ".gz")) {
       if (args_->verbose > 1) {
         threads.push_back(std::thread([=]() { trainThreadFromArchive(0, callback); }));
       } else {

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -748,7 +748,7 @@ void FastText::trainThreadFromArchive(int32_t threadId, const TrainCallback& cal
 void FastText::saveInterm(real progress) {
   std::ostringstream ss;
   ss.precision(2);
-  ss << args_->output << "_" << std::fixed << progress << ".bin";
+  ss << args_->output << "-" << std::fixed << progress << ".bin";
   std::cerr << "Saving model at " << progress << std::endl;
   saveModel(ss.str());
 }

--- a/src/fasttext.cc
+++ b/src/fasttext.cc
@@ -747,10 +747,14 @@ void FastText::trainThreadFromArchive(int32_t threadId, const TrainCallback& cal
 
 void FastText::saveInterm(real progress) {
   std::ostringstream ss;
-  ss.precision(2);
-  ss << args_->output << "-" << std::fixed << progress << ".bin";
-  std::cerr << "Saving model at " << progress << std::endl;
+  auto prev_precision = ss.precision(2);
+  ss << args_->output
+     << "-" << std::fixed << progress
+     << "-loss" << std::setprecision(4) << loss_
+     << ".bin";
+  std::cerr << std::endl << "Saving model at " << progress << std::endl;
   saveModel(ss.str());
+  ss.precision(prev_precision);
 }
 
 std::shared_ptr<Matrix> FastText::getInputMatrixFromFile(

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -56,6 +56,7 @@ class FastText {
   void addInputVector(Vector&, int32_t) const;
   void trainThread(int32_t, const TrainCallback& callback);
   void trainThreadFromArchive(int32_t, const TrainCallback& callback);
+  void saveInterm(real);
   std::vector<std::pair<real, std::string>> getNN(
       const DenseMatrix& wordVectors,
       const Vector& queryVec,

--- a/src/fasttext.h
+++ b/src/fasttext.h
@@ -55,6 +55,7 @@ class FastText {
   void startThreads(const TrainCallback& callback = {});
   void addInputVector(Vector&, int32_t) const;
   void trainThread(int32_t, const TrainCallback& callback);
+  void trainThreadFromArchive(int32_t, const TrainCallback& callback);
   std::vector<std::pair<real, std::string>> getNN(
       const DenseMatrix& wordVectors,
       const Vector& queryVec,

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -48,6 +48,14 @@ bool compareFirstLess(const std::pair<double, double>& l, const double& r) {
   return l.first < r;
 }
 
+bool endsWith(const std::string& str, const std::string& suffix) {
+  if (str.size() < suffix.size())
+    return false;
+  if (str.substr(str.size() - suffix.size()) == suffix)
+    return true;
+  return false;
+}
+
 } // namespace utils
 
 } // namespace fasttext

--- a/src/utils.h
+++ b/src/utils.h
@@ -67,6 +67,8 @@ class ClockPrint {
 
 bool compareFirstLess(const std::pair<double, double>& l, const double& r);
 
+bool endsWith(const std::string& str, const std::string& suffix);
+
 } // namespace utils
 
 } // namespace fasttext


### PR DESCRIPTION
* can read xz archives on input (implementation from boost::iostreams)
* print progess info in single thread mode

Bugs found:
* keepTraining condition is based on the number of tokens consumed. It doesn't account the discarded tokens and restarts reading the file from the beginning even with epoch=1. Not fixed yet to keep results reproducible.
* Debug and Release build produce different .bin files for the same corpus with same parameters.